### PR TITLE
chore: deliberately break a dependency

### DIFF
--- a/components/webui/requirements.txt
+++ b/components/webui/requirements.txt
@@ -940,9 +940,7 @@ pycparser==2.22 \
     # via
     #   -c reqs/constraints.txt
     #   cffi
-pydantic==2.7.4 \
-    --hash=sha256:0c84efd9548d545f63ac0060c1e4d39bb9b14db8b3c0652338aecc07b5adec52 \
-    --hash=sha256:ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0
+pydantic==2.8.2
     # via
     #   -c reqs/constraints.txt
     #   google-cloud-aiplatform


### PR DESCRIPTION
changed pydantic in reqs/requirements.txt but not anywhere else, so it violates the contraint.
Test what commands in my CI can catch this by install dependencies.

Then, test how I modify dependabot config to update in all the relevant places (requirements_in ? constraints ? pyproject? -e ?